### PR TITLE
Add ability to toggle window state via hotkey.

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1,3 +1,4 @@
+use std::fmt::{Display, Error, Formatter};
 use std::mem;
 use std::process;
 use std::ptr;
@@ -34,6 +35,17 @@ impl Rect {
             width: 0,
             height: 0,
         }
+    }
+}
+
+impl Display for Rect {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        writeln!(f, "x: {}", self.x)?;
+        writeln!(f, "y: {}", self.y)?;
+        writeln!(f, "width: {}", self.width)?;
+        writeln!(f, "height: {}", self.height)?;
+
+        Ok(())
     }
 }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -36,6 +36,12 @@ impl Rect {
             height: 0,
         }
     }
+
+    pub fn adjust_for_border(&mut self, border: (i32, i32)) {
+        self.x -= border.0;
+        self.width += border.0 * 2;
+        self.height += border.1;
+    }
 }
 
 impl Display for Rect {

--- a/src/config.rs
+++ b/src/config.rs
@@ -99,6 +99,7 @@ pub struct Config {
     pub window_padding: u8,
     pub hotkey: String,
     pub hotkey_quick_resize: Option<String>,
+    pub hotkey_maximize_toggle: Option<String>,
     pub auto_start: bool,
 }
 
@@ -109,6 +110,7 @@ impl Default for Config {
             window_padding: 10,
             hotkey: "CTRL+ALT+S".to_string(),
             hotkey_quick_resize: None,
+            hotkey_maximize_toggle: None,
             auto_start: false,
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,9 @@ hotkey: CTRL+ALT+S
 # Hotkey to activate grid for a quick resize. Grid will automatically close after resize operation.
 #hotkey_quick_resize: CTRL+ALT+Q
 
+# Hotkey to maximize / restore the active window
+#hotkey_maximize_toggle: CTRL+ALT+X
+
 # Automatically launch program on startup
 auto_start: false
 ";

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -154,9 +154,7 @@ impl Grid {
         self.cursor_down = false;
         self.selected_tile = None;
         self.hovered_tile = None;
-        self.active_window = None;
         self.grid_window = None;
-        self.previous_resize = None;
         self.quick_resize = false;
 
         self.tiles.iter_mut().for_each(|row| {

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -415,6 +415,18 @@ impl Grid {
         self.selected_tile != previously_selected
     }
 
+    pub unsafe fn get_max_area(&self) -> Rect {
+        let from_zone = self.zone_area(0, 0);
+        let to_zone = self.zone_area(self.rows() - 1, self.columns() - 1);
+
+        Rect {
+            x: from_zone.x,
+            y: from_zone.y,
+            width: (to_zone.x + to_zone.width) - from_zone.x,
+            height: (to_zone.y + to_zone.height) - from_zone.y,
+        }
+    }
+
     pub unsafe fn selected_area(&mut self) -> Option<Rect> {
         if let Some(shift_rect) = self.shift_hover_and_calc_rect(false) {
             return Some(shift_rect);

--- a/src/hotkey.rs
+++ b/src/hotkey.rs
@@ -15,6 +15,7 @@ use crate::CHANNEL;
 pub enum HotkeyType {
     Main,
     QuickResize,
+    Maximize,
 }
 
 pub fn spawn_hotkey_thread(hotkey_str: &str, hotkey_type: HotkeyType) {

--- a/src/hotkey.rs
+++ b/src/hotkey.rs
@@ -11,7 +11,7 @@ use crate::common::report_and_exit;
 use crate::Message;
 use crate::CHANNEL;
 
-#[derive(PartialEq, Clone, Copy)]
+#[derive(PartialEq, Clone, Copy, Debug)]
 pub enum HotkeyType {
     Main,
     QuickResize,

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,16 +129,13 @@ fn main() {
                                 grid.active_window = Some(active_window);
                                 active_window
                             };
+
                             let active_rect = active_window.rect();
 
                             ShowWindow(active_window.0, SW_RESTORE);
 
-                            let border_adj = active_window.transparent_border();
-
                             let mut max_rect = grid.get_max_area();
-                            max_rect.x -= border_adj.0;
-                            max_rect.width += border_adj.0 * 2;
-                            max_rect.height += border_adj.1;
+                            max_rect.adjust_for_border(active_window.transparent_border());
 
                             if let Some((_, previous_rect)) = grid.previous_resize {
                                 if active_rect == max_rect {

--- a/src/window.rs
+++ b/src/window.rs
@@ -12,7 +12,7 @@ pub use grid::spawn_grid_window;
 mod preview;
 pub use preview::spawn_preview_window;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Window(pub HWND);
 
 unsafe impl Send for Window {}

--- a/src/window/grid.rs
+++ b/src/window/grid.rs
@@ -204,11 +204,7 @@ unsafe extern "system" fn callback(
                     if grid.previous_resize != Some((active_window, rect)) {
                         ShowWindow(active_window.0, SW_RESTORE);
 
-                        let border_adj = active_window.transparent_border();
-
-                        rect.x -= border_adj.0;
-                        rect.width += border_adj.0 * 2;
-                        rect.height += border_adj.1;
+                        rect.adjust_for_border(active_window.transparent_border());
 
                         active_window.set_pos(rect, None);
 


### PR DESCRIPTION
Adds the possibility to define a optional hotkey for toggling between maximized window state and previous window state.

A possible use case would be in case of a 50/50 split to shortly maximize one window e.g. for better readability and then go back to the 50/50 split.

There might be a better way to do this, especially to get the full grid dimensions but it seems to work as indented.