### PR TITLE
Refactoring.

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -5,9 +5,11 @@ use std::ptr;
 
 use winapi::shared::windef::{POINT, RECT};
 use winapi::um::winuser::{
-    GetCursorPos, GetMonitorInfoW, MessageBoxW, MonitorFromPoint, MB_OK, MONITORINFOEXW,
-    MONITOR_DEFAULTTONEAREST,
+    GetCursorPos, GetForegroundWindow, GetMonitorInfoW, MessageBoxW, MonitorFromPoint, MB_OK,
+    MONITORINFOEXW, MONITOR_DEFAULTTONEAREST,
 };
+
+use crate::window::Window;
 
 use crate::str_to_wide;
 
@@ -77,6 +79,11 @@ impl From<Rect> for RECT {
     }
 }
 
+pub fn get_foreground_window() -> Window {
+    let hwnd = unsafe { GetForegroundWindow() };
+    Window(hwnd)
+}
+
 pub unsafe fn get_work_area() -> Rect {
     let active_monitor = {
         let mut cursor_pos: POINT = mem::zeroed();
@@ -113,15 +120,20 @@ pub unsafe fn get_active_monitor_name() -> String {
     String::from_utf16_lossy(&info.szDevice)
 }
 
-pub unsafe fn report_and_exit(error_msg: &str) {
-    let mut error_msg = str_to_wide!(error_msg);
-
-    MessageBoxW(
-        ptr::null_mut(),
-        error_msg.as_mut_ptr(),
-        ptr::null_mut(),
-        MB_OK,
-    );
-
+pub fn report_and_exit(error_msg: &str) {
+    show_msg_box(error_msg);
     process::exit(1);
+}
+
+pub fn show_msg_box(message: &str) {
+    let mut message = str_to_wide!(message);
+
+    unsafe {
+        MessageBoxW(
+            ptr::null_mut(),
+            message.as_mut_ptr(),
+            ptr::null_mut(),
+            MB_OK,
+        );
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,9 +60,7 @@ pub fn toggle_autostart() {
         if let Ok(mut config) = File::open(&config_path) {
             let mut config_str = String::new();
 
-            config
-                .read_to_string(&mut config_str)
-                .expect("Can not read config.");
+            let _ = config.read_to_string(&mut config_str);
 
             let re_line = Regex::new(r"(?m)^(auto_start:)(.*)$").unwrap();
             let updated_config = if let Some(cap) = re_line.captures_iter(&config_str).next() {
@@ -90,7 +88,7 @@ pub fn toggle_autostart() {
                 format!("{}\n\nauto_start: true", config_str)
             };
 
-            write(&config_path, updated_config).expect("Can not write to config.");
+            let _ = write(&config_path, updated_config);
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,7 +73,7 @@ pub fn toggle_autostart() {
                     let enabled = re_cap.find(&cap[2].trim());
 
                     let updated_config = re_line.replace(&config_str, |caps: &Captures| {
-                        format!("{} {}", &caps[1], enabled.is_some())
+                        format!("{} {}", &caps[1], !enabled.is_some())
                     });
 
                     Some(updated_config.as_ref().to_owned())

--- a/src/event.rs
+++ b/src/event.rs
@@ -40,9 +40,7 @@ pub fn spawn_foreground_hook(close_msg: Receiver<()>) {
             };
 
             select! {
-                recv(close_msg) -> _ => {
-                    break;
-                }
+                recv(close_msg) -> _ => break,
                 default(Duration::from_millis(10)) => {}
             }
         }

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -190,8 +190,8 @@ impl Grid {
         (width, height)
     }
 
-    unsafe fn zone_area(&self, row: usize, column: usize) -> Rect {
-        let work_area = get_work_area();
+    fn zone_area(&self, row: usize, column: usize) -> Rect {
+        let work_area = unsafe { get_work_area() };
 
         let zone_width = (work_area.width
             - self.border_margins as i32 * 2
@@ -268,8 +268,8 @@ impl Grid {
         }
     }
 
-    pub unsafe fn reposition(&mut self) {
-        let work_area = get_work_area();
+    pub fn reposition(&mut self) {
+        let work_area = unsafe { get_work_area() };
         let dimensions = self.dimensions();
 
         let rect = Rect {
@@ -413,7 +413,7 @@ impl Grid {
         self.selected_tile != previously_selected
     }
 
-    pub unsafe fn get_max_area(&self) -> Rect {
+    pub fn get_max_area(&self) -> Rect {
         let from_zone = self.zone_area(0, 0);
         let to_zone = self.zone_area(self.rows() - 1, self.columns() - 1);
 
@@ -441,6 +441,12 @@ impl Grid {
         self.tiles
             .iter_mut()
             .for_each(|row| row.iter_mut().for_each(|tile| tile.hovered = false));
+    }
+
+    pub fn unselect_all_tiles(&mut self) {
+        self.tiles
+            .iter_mut()
+            .for_each(|row| row.iter_mut().for_each(|tile| tile.selected = false));
     }
 
     pub unsafe fn draw(&self, window: Window) {

--- a/src/hotkey.rs
+++ b/src/hotkey.rs
@@ -24,13 +24,11 @@ pub fn spawn_hotkey_thread(hotkey_str: &str, hotkey_type: HotkeyType) {
         .map(|s| s.trim().to_string())
         .collect();
 
-    if !(2..6).contains(&hotkey.len()) {
-        unsafe {
-            report_and_exit(&format!(
-                "Invalid hotkey <{}>: Combination must be between 2 to 5 keys long.",
-                hotkey_str
-            ));
-        }
+    if hotkey.len() < 2 || hotkey.len() > 5 {
+        report_and_exit(&format!(
+            "Invalid hotkey <{}>: Combination must be between 2 to 5 keys long.",
+            hotkey_str
+        ));
     }
 
     let virtual_key_char = hotkey.pop().unwrap().chars().next().unwrap();
@@ -70,10 +68,7 @@ fn compile_modifiers(activators: &[String], hotkey_str: &str) -> u32 {
             "CTRL" => code |= MOD_CONTROL as u32,
             "SHIFT" => code |= MOD_SHIFT as u32,
             "WIN" => code |= MOD_WIN as u32,
-
-            _ => unsafe {
-                report_and_exit(&format!("Invalid hotkey <{}>: Unidentified modifier in hotkey combination. Valid modifiers are CTRL, ALT, SHIFT, WIN.", hotkey_str))
-            },
+            _ => report_and_exit(&format!("Invalid hotkey <{}>: Unidentified modifier in hotkey combination. Valid modifiers are CTRL, ALT, SHIFT, WIN.", hotkey_str))
         }
     }
     code

--- a/src/window.rs
+++ b/src/window.rs
@@ -2,7 +2,9 @@ use std::mem;
 use std::ptr;
 
 use winapi::shared::windef::HWND;
-use winapi::um::winuser::{GetWindowInfo, GetWindowRect, SetWindowPos, SWP_NOACTIVATE, WINDOWINFO};
+use winapi::um::winuser::{
+    GetWindowInfo, GetWindowRect, SetWindowPos, ShowWindow, SWP_NOACTIVATE, SW_RESTORE, WINDOWINFO,
+};
 
 use crate::common::Rect;
 
@@ -51,8 +53,8 @@ impl Window {
         info.into()
     }
 
-    pub unsafe fn transparent_border(self) -> (i32, i32) {
-        let info = self.info();
+    pub fn transparent_border(self) -> (i32, i32) {
+        let info = unsafe { self.info() };
 
         let x = {
             (info.window_rect.x - info.client_rect.x)
@@ -65,6 +67,12 @@ impl Window {
         };
 
         (x, y)
+    }
+
+    pub fn restore(&mut self) {
+        unsafe {
+            ShowWindow(self.0, SW_RESTORE);
+        };
     }
 }
 

--- a/src/window/grid.rs
+++ b/src/window/grid.rs
@@ -14,10 +14,10 @@ use winapi::um::libloaderapi::GetModuleHandleW;
 use winapi::um::wingdi::{CreateSolidBrush, RGB};
 use winapi::um::winuser::{
     CreateWindowExW, DefWindowProcW, DispatchMessageW, InvalidateRect, LoadCursorW, PeekMessageW,
-    RegisterClassExW, SendMessageW, ShowWindow, TranslateMessage, IDC_ARROW, SW_RESTORE,
-    VK_CONTROL, VK_DOWN, VK_ESCAPE, VK_F1, VK_F2, VK_F3, VK_F4, VK_F5, VK_F6, VK_LEFT, VK_RIGHT,
-    VK_SHIFT, VK_UP, WM_KEYDOWN, WM_KEYUP, WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MOUSELEAVE,
-    WM_MOUSEMOVE, WM_PAINT, WNDCLASSEXW, WS_EX_TOOLWINDOW, WS_EX_TOPMOST, WS_POPUP,
+    RegisterClassExW, SendMessageW, TranslateMessage, IDC_ARROW, VK_CONTROL, VK_DOWN, VK_ESCAPE,
+    VK_F1, VK_F2, VK_F3, VK_F4, VK_F5, VK_F6, VK_LEFT, VK_RIGHT, VK_SHIFT, VK_UP, WM_KEYDOWN,
+    WM_KEYUP, WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MOUSELEAVE, WM_MOUSEMOVE, WM_PAINT, WNDCLASSEXW,
+    WS_EX_TOOLWINDOW, WS_EX_TOPMOST, WS_POPUP,
 };
 
 use crate::common::{get_work_area, Rect};
@@ -202,7 +202,7 @@ unsafe extern "system" fn callback(
             let repaint = if let Some(mut rect) = grid.selected_area() {
                 if let Some(mut active_window) = grid.active_window {
                     if grid.previous_resize != Some((active_window, rect)) {
-                        ShowWindow(active_window.0, SW_RESTORE);
+                        active_window.restore();
 
                         rect.adjust_for_border(active_window.transparent_border());
 
@@ -214,6 +214,8 @@ unsafe extern "system" fn callback(
                             let _ = sender.send(Message::CloseWindows);
                         }
                     }
+
+                    grid.unselect_all_tiles();
                 }
 
                 true


### PR DESCRIPTION
I did some basic refactoring.

While doing so I noticed that you implemented most components solely with the WinAPI. Is there a reason why  you wouldn't use https://github.com/qdot/systray-rs for the tray for example? Crates that offer abstraction over the native API would increase readability in my opinion, in case they support the same features of course.